### PR TITLE
fix lodestone causing item loss

### DIFF
--- a/src/main/java/de/blazemcworld/blazinggames/teleportanchor/LodestoneInventoryClickEventListener.java
+++ b/src/main/java/de/blazemcworld/blazinggames/teleportanchor/LodestoneInventoryClickEventListener.java
@@ -35,8 +35,9 @@ public class LodestoneInventoryClickEventListener implements Listener {
 
     @EventHandler
     public void onLodestoneClick(InventoryClickEvent event) {
-        if (event.getView().title().equals(Component.text("Teleportation Menu").color(NamedTextColor.AQUA)) && event.getCurrentItem() != null) {
+        if (event.getView().title().equals(Component.text("Teleportation Menu").color(NamedTextColor.AQUA))) {
             event.setCancelled(true);
+            if (event.getCurrentItem() == null) return;
             Player player = (Player) event.getWhoClicked();
             ItemMeta meta = event.getCurrentItem().getItemMeta();
 


### PR DESCRIPTION
this is because there was techncially no current item if you were using number keys to get items into the gui, and that would cause item loss since you cant get the items back out