### PR TITLE
make discord link codes more user-friendly

### DIFF
--- a/src/main/java/de/blazemcworld/blazinggames/discord/WhitelistManagement.java
+++ b/src/main/java/de/blazemcworld/blazinggames/discord/WhitelistManagement.java
@@ -152,7 +152,7 @@ public class WhitelistManagement {
     }
 
     public String createLinkCode(String username, UUID user) {
-        byte[] bytes = new byte[8];
+        byte[] bytes = new byte[3];
         new Random().nextBytes(bytes);
         StringBuilder out = new StringBuilder();
 
@@ -160,15 +160,15 @@ public class WhitelistManagement {
             out.append(String.format("%02x", b));
         }
 
-        linkCodes.put(out.toString(), new Pair<>(username, user));
+        linkCodes.put(out.toString().toUpperCase(), new Pair<>(username, user));
         return out.toString();
     }
 
     public Pair<String, UUID> getLinkCodeUser(String code) {
-        return linkCodes.getIfPresent(code);
+        return linkCodes.getIfPresent(code.toUpperCase());
     }
 
     public void invalidateLinkCode(String code) {
-        linkCodes.invalidate(code);
+        linkCodes.invalidate(code.toUpperCase());
     }
 }


### PR DESCRIPTION
- make them 6 characters instead of 16
- make them case-insensitive but uppercase by default

not tested but it's 4 lines changed so